### PR TITLE
Send state_id over time to have availability 

### DIFF
--- a/etc/modules/graphite2.cfg
+++ b/etc/modules/graphite2.cfg
@@ -73,5 +73,12 @@ define module {
    #send_warning      False
    #send_critical     False
    #send_min          False
-   #send_max          False
+   #send_max          False   
+   
+   # Options to send state for hosts or services.
+   # This feature is useful to have a availability graph
+   # 1 is to enable - 0 is to disable 
+   state_enable 1 # Enable or disable this feature
+   state_host   1 # If state_enable is enable, will send state for host
+   state_service 1 # If state_enable is enable, will send state for service
 }

--- a/etc/modules/graphite2.cfg
+++ b/etc/modules/graphite2.cfg
@@ -78,7 +78,7 @@ define module {
    # Options to send state for hosts or services.
    # This feature is useful to have a availability graph
    # 1 is to enable - 0 is to disable 
-   state_enable 1 # Enable or disable this feature
-   state_host   1 # If state_enable is enable, will send state for host
-   state_service 1 # If state_enable is enable, will send state for service
+   state_enable 0 # Enable or disable this feature
+   state_host   0 # If state_enable is enable, will send state for host
+   state_service 0 # If state_enable is enable, will send state for service
 }

--- a/etc/modules/graphite2.cfg
+++ b/etc/modules/graphite2.cfg
@@ -77,8 +77,12 @@ define module {
    
    # Options to send state for hosts or services.
    # This feature is useful to have a availability graph
-   # 1 is to enable - 0 is to disable 
-   state_enable 0 # Enable or disable this feature
-   state_host   0 # If state_enable is enable, will send state for host
-   state_service 0 # If state_enable is enable, will send state for service
+   # 1 is to enable - 0 is to disable
+   # Default all is disable
+   #-- Enable or disable this feature
+   state_enable 0
+   #-- If state_enable is enable, will send state for all hosts
+   state_host   0
+   #-- If state_enable is enable, will send state for all services
+   state_service 0
 }

--- a/module/module.py
+++ b/module/module.py
@@ -252,7 +252,7 @@ class Graphite_broker(BaseModule):
     def manage_service_check_result_brok(self, b):
         host_name = b.data['host_name']
         state_id = b.data['state_id']
-	service_description = b.data['service_description']
+        service_description = b.data['service_description']
         service_id = host_name+"/"+service_description
         logger.debug("[Graphite] service check result: %s", service_id)
 
@@ -303,7 +303,6 @@ class Graphite_broker(BaseModule):
             path = '.'.join((hname, self.graphite_data_source, desc))
         else:
             path = '.'.join((hname, desc))
-	
 
         #Send state to Graphite
         state_query = []
@@ -333,8 +332,7 @@ class Graphite_broker(BaseModule):
     def manage_host_check_result_brok(self, b):
         host_name = b.data['host_name']
         logger.debug("[Graphite] host check result: %s", host_name)
-	
-	state_id = b.data['state_id']
+        state_id = b.data['state_id']
         # If host initial status brok has not been received, ignore ...
         if host_name not in self.hosts_cache:
             logger.warning("[Graphite] received service check result for an unknown host: %s", host_name)
@@ -373,7 +371,7 @@ class Graphite_broker(BaseModule):
         else:
             path = hname
 
-	#Send state to Graphite        
+        #Send state to Graphite        
         state_query = []
         state_query.append("%s.available %s %d" % (path, state_id, check_time))
         state_packet = '\n'.join(state_query) + '\n'
@@ -383,7 +381,7 @@ class Graphite_broker(BaseModule):
         except IOError:
                 logger.error("[Graphite broker] Failed sendind state o the Graphite Carbon.")
 
-	if len(couples) == 0:
+        if len(couples) == 0:
             logger.debug("[Graphite] no metrics to send ...")
             return
 
@@ -403,4 +401,4 @@ class Graphite_broker(BaseModule):
             l = self.to_q.get()
             for b in l:
                 b.prepare()
-		self.manage_brok(b)
+                self.manage_brok(b)

--- a/module/module.py
+++ b/module/module.py
@@ -82,14 +82,14 @@ class Graphite_broker(BaseModule):
         logger.info('[Graphite] Configuration - maximum cache commit volume: %d packets', self.cache_commit_volume)
         self.cache = deque(maxlen=self.cache_max_length)
 
-	# Options to send state
-	self.state_enable = int(getattr(modconf, 'state_enable', '0'))
-	logger.info('[Graphite] Configuration - Send state to Graphite: %d ', self.state_enable)
-	self.state_host = int(getattr(modconf, 'state_host', '0'))
+        # Options to send state
+        self.state_enable = int(getattr(modconf, 'state_enable', '0'))
+        logger.info('[Graphite] Configuration - Send state to Graphite: %d ', self.state_enable)
+        self.state_host = int(getattr(modconf, 'state_host', '0'))
         logger.info('[Graphite] Configuration - Send state for hosts to Graphite: %d ', self.state_host)
-	self.state_service = int(getattr(modconf, 'state_service', '0'))
+        self.state_service = int(getattr(modconf, 'state_service', '0'))
         logger.info('[Graphite] Configuration - Send state for service to Graphite: %d ', self.state_service)
-	
+
         # Used to reset check time into the scheduled time.
         # Carbon/graphite does not like latency data and creates blanks in graphs
         # Every data with "small" latency will be considered create at scheduled time
@@ -260,7 +260,7 @@ class Graphite_broker(BaseModule):
     def manage_service_check_result_brok(self, b):
         host_name = b.data['host_name']
         state_id = b.data['state_id']
-	last_state_id = b.data['last_state_id']
+        last_state_id = b.data['last_state_id']
         service_description = b.data['service_description']
         service_id = host_name+"/"+service_description
         logger.debug("[Graphite] service check result: %s", service_id)
@@ -312,18 +312,18 @@ class Graphite_broker(BaseModule):
             path = '.'.join((hname, self.graphite_data_source, desc))
         else:
             path = '.'.join((hname, desc))
-	
+
         #Send state to Graphite
         state_query = []
         state_query.append("%s.available %s %d" % (path, state_id, check_time))
         state_packet = '\n'.join(state_query) + '\n'
         #logger.error("---SERVICE--- %s", state_packet)
         if (self.state_enable == 1 and self.state_service == 1 and state_id != last_state_id):
-		try:
-                	self.send_packet(state_packet)
-			#logger.error("[Graphite broker] -------------- Service %s last: %d | now: %d",path, last_state_id ,state_id)
-		except IOError:
-                	logger.error("[Graphite broker] Failed sending state to the Graphite Carbon.")
+                try:
+                        self.send_packet(state_packet)
+                        #logger.error("[Graphite broker] -------------- Service %s last: %d | now: %d",path, last_state_id ,state_id)
+                except IOError:
+                        logger.error("[Graphite broker] Failed sending state to the Graphite Carbon.")
 
         if len(couples) == 0:
             logger.debug("[Graphite] no metrics to send ...")
@@ -341,10 +341,10 @@ class Graphite_broker(BaseModule):
 
     # A host check result brok has just arrived, we UPDATE data info with this
     def manage_host_check_result_brok(self, b):   
-	host_name = b.data['host_name']
+        host_name = b.data['host_name']
         logger.debug("[Graphite] host check result: %s", host_name)
         state_id = b.data['state_id']
-	last_state_id = b.data['last_state_id']
+        last_state_id = b.data['last_state_id']
         # If host initial status brok has not been received, ignore ...
         if host_name not in self.hosts_cache:
             logger.warning("[Graphite] received service check result for an unknown host: %s", host_name)
@@ -388,13 +388,13 @@ class Graphite_broker(BaseModule):
         state_query.append("%s.available %s %d" % (path, state_id, check_time))
         state_packet = '\n'.join(state_query) + '\n'
         #logger.error("---HOST--- %s", state_packet)
-	
+
         if (self.state_enable == 1 and self.state_host == 1 and state_id != last_state_id):
-		try:
-                	self.send_packet(state_packet)
-			#logger.error("---HOST STATE SENDING TO GRAPHITE--- previous_state: %d | new_state: %d",last_state_id, state_id)
-        	except IOError:
-                	logger.error("[Graphite broker] Failed sending state to the Graphite Carbon.")
+                try:
+                        self.send_packet(state_packet)
+                        #logger.error("---HOST STATE SENDING TO GRAPHITE--- previous_state: %d | new_state: %d",last_state_id, state_id)
+                except IOError:
+                        logger.error("[Graphite broker] Failed sending state to the Graphite Carbon.")
         if len(couples) == 0:
             logger.debug("[Graphite] no metrics to send ...")
             return

--- a/module/module.py
+++ b/module/module.py
@@ -82,6 +82,14 @@ class Graphite_broker(BaseModule):
         logger.info('[Graphite] Configuration - maximum cache commit volume: %d packets', self.cache_commit_volume)
         self.cache = deque(maxlen=self.cache_max_length)
 
+	# Options to send state
+	self.state_enable = int(getattr(modconf, 'state_enable', '0'))
+	logger.info('[Graphite] Configuration - Send state to Graphite: %d ', self.state_enable)
+	self.state_host = int(getattr(modconf, 'state_host', '0'))
+        logger.info('[Graphite] Configuration - Send state for hosts to Graphite: %d ', self.state_host)
+	self.state_service = int(getattr(modconf, 'state_service', '0'))
+        logger.info('[Graphite] Configuration - Send state for service to Graphite: %d ', self.state_service)
+	
         # Used to reset check time into the scheduled time.
         # Carbon/graphite does not like latency data and creates blanks in graphs
         # Every data with "small" latency will be considered create at scheduled time
@@ -303,16 +311,17 @@ class Graphite_broker(BaseModule):
             path = '.'.join((hname, self.graphite_data_source, desc))
         else:
             path = '.'.join((hname, desc))
-
+	
         #Send state to Graphite
         state_query = []
         state_query.append("%s.available %s %d" % (path, state_id, check_time))
         state_packet = '\n'.join(state_query) + '\n'
         #logger.error("---SERVICE--- %s", state_packet)
-        try:
-                self.send_packet(state_packet)
-        except IOError:
-                logger.error("[Graphite broker] Failed sendind state o the Graphite Carbon.")
+        if (self.state_enable == 1 and self.state_service == 1):
+		try:
+                	self.send_packet(state_packet)
+        	except IOError:
+                	logger.error("[Graphite broker] Failed sending state to the Graphite Carbon.")
 
         if len(couples) == 0:
             logger.debug("[Graphite] no metrics to send ...")
@@ -376,11 +385,11 @@ class Graphite_broker(BaseModule):
         state_query.append("%s.available %s %d" % (path, state_id, check_time))
         state_packet = '\n'.join(state_query) + '\n'
         #logger.error("---HOST--- %s", state_packet)
-        try:
-                self.send_packet(state_packet)
-        except IOError:
-                logger.error("[Graphite broker] Failed sendind state o the Graphite Carbon.")
-
+        if (self.state_enable == 1 and self.state_host == 1):
+		try:
+                	self.send_packet(state_packet)
+        	except IOError:
+                	logger.error("[Graphite broker] Failed sending state to the Graphite Carbon.")
         if len(couples) == 0:
             logger.debug("[Graphite] no metrics to send ...")
             return

--- a/module/module.py
+++ b/module/module.py
@@ -403,4 +403,4 @@ class Graphite_broker(BaseModule):
             l = self.to_q.get()
             for b in l:
                 b.prepare()
-		        self.manage_brok(b)
+		self.manage_brok(b)


### PR DESCRIPTION
This Pull request send availability for hosts and services in Graphite over time.
It's useful to see when an host/service is down over time.

How it's works ?
The broker receive all data from all check. A function for host read data about state and other function do same for service.
**For HOSTS i added:**

```
 def manage_host_check_result_brok(self, b):
    state_id = b.data['state_id'] #Read state_id, it's a number
[...]
#Send state to Graphite        
        state_query = []
        state_query.append("%s.available %s %d" % (path, state_id, check_time))
        state_packet = '\n'.join(state_query) + '\n'
        #Query example: myshost.available 1 ​1458774003
        #logger.error("------ %s", state_packet)
        try:
                self.send_packet(state_packet) 
        except IOError:
                logger.error("[Graphite broker] Failed sendind state o the Graphite Carbon.")
[...]

```

Same logic for services

The result with Grafana and Graphite as datasource
![result](https://cloud.githubusercontent.com/assets/15362041/16617481/3725687c-4384-11e6-90e4-75d963063718.png)
