### PR TITLE
Removes extraneous "\n" at the end of packets

### DIFF
--- a/module/module.py
+++ b/module/module.py
@@ -168,7 +168,8 @@ class Graphite_broker(BaseModule):
             logger.info("[Graphite] time to flush %d cached metrics packet(s) (%2.4f)", commit_count, time() - now)
 
         try:
-            self.con.sendall(packet)
+            # Ensure that one and only one "\n" ends the packet
+            self.con.sendall(packet.rstrip() + "\n")
             logger.debug("[Graphite] Data sent to Carbon: \n%s", packet)
         except IOError:
             logger.warning("[Graphite] Failed sending data to the Graphite Carbon instance !"


### PR DESCRIPTION
This fixes warnings like this /var/log/carbon/listener.log :

17/07/2016 03:44:29 :: invalid line () received from client 127.0.0.1:47869, ignoring
17/07/2016 03:44:29 :: invalid line () received from client 127.0.0.1:47869, ignoring
17/07/2016 03:44:29 :: invalid line () received from client 127.0.0.1:47869, ignoring
17/07/2016 03:44:30 :: invalid line () received from client 127.0.0.1:47869, ignoring

Empty string between parenthesis suggests that an empty line is sent to
graphite.

Indeed, inspection of lo interface with tcpdump/wireshark shows packets ending with "0a0a".

The suggested fix is not very elegant but it does the job, at least on my
system (centos 7.2, shinken 2.4.3 and graphite-web 0.9.15 from EPEL
repo, and mod-graphite as downloaded from shinken.io, which I found to
be identical to the current module in "refactored" branch).
